### PR TITLE
Remove Blockie Account Icons

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "forehash-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forehash-ui",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "dependencies": {
     "@drizzle/react-components": "^1.5.1",

--- a/app/src/components/Blockie.js
+++ b/app/src/components/Blockie.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Image } from 'react-bootstrap';
+//import { Image } from 'react-bootstrap';
 
-const Blockie = props => {
+const Blockie = _props => {
 
     return (
-        <Image src={"https://eth.vanity.show/" + props.account}
-                alt={"Identicon of ether address" + props.account}
-                roundedCircle />
+        <span></span>
+        // <Image src={"https://eth.vanity.show/" + props.account}
+        //         alt={"Identicon of ether address" + props.account}
+        //         roundedCircle />
     );
 }
 

--- a/app/src/components/full_list/PublicationCard.js
+++ b/app/src/components/full_list/PublicationCard.js
@@ -17,7 +17,7 @@ const PublicationCard = props => {
             <Card>
                 <Card.Body>
                 <Container>
-                    <Row>
+                    {/* <Row>
                         <Col xs="12">
                             <Image src={"https://eth.vanity.show/" + account}
                                     style={{
@@ -27,7 +27,7 @@ const PublicationCard = props => {
                                     roundedCircle
                             />
                         </Col>
-                    </Row>
+                    </Row> */}
                     <Row className="mt-3">
                         <Col xs="12">
                             <center>

--- a/app/src/components/sublist/AccountHeader.js
+++ b/app/src/components/sublist/AccountHeader.js
@@ -6,10 +6,11 @@ import { Col, Row } from 'react-bootstrap';
 const AccountHeader = props => {
     return (
             <Row>
-                <Col xs="2" sm="1">
+                {/* <Col xs="2" sm="1">
                     <Blockie account={props.account} />
-                </Col>
-                <Col className="ml-4">
+                </Col> */}
+                {/* <Col className="ml-4"> */}
+                <Col>
                     <h5 className="text-dark">{props.account.slice(0, 14) + "..."}</h5>
                     <p className="text-secondary">
                         {props.submissions.length} Predictions ({props.revelations.length} Revealed)


### PR DESCRIPTION
The service used for this is broken. Until we get a chance to properly do the rendering ourselves, just pull the blockie rendering out of the app so it doesn't look horribly broken.